### PR TITLE
docs: fix README clone URL and typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Please be respectful and constructive in all interactions. We are committed to p
 
 ```bash
 # Clone the repository
-git clone https://github.com/alibaba/assistant-agent.git
-cd assistant-agent
+git clone https://github.com/spring-ai-alibaba/AssistantAgent.git
+cd AssistantAgent
 
 # Build the project
 mvn clean install -DskipTests
@@ -97,8 +97,8 @@ mvn spring-boot:run
 
 ```bash
 # Fork on GitHub, then:
-git clone https://github.com/YOUR_USERNAME/assistant-agent.git
-cd assistant-agent
+git clone https://github.com/YOUR_USERNAME/AssistantAgent.git
+cd AssistantAgent
 git checkout -b feature/your-feature-name
 
 # Make changes...

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Below is an end-to-end flow example of how Assistant Agent processes a complete 
 ### Project Structure
 
 ```
-assistant-agent/
+AssistantAgent/
 ├── assistant-agent-common          # Common tools, enums, constants
 ├── assistant-agent-core            # Core engine: GraalVM executor, tool registry
 ├── assistant-agent-extensions      # Extension modules:
@@ -89,8 +89,8 @@ assistant-agent/
 ### 1. Clone and Build
 
 ```bash
-git clone https://github.com/alibaba/assistant-agent.git
-cd assistant-agent
+git clone https://github.com/spring-ai-alibaba/AssistantAgent.git
+cd AssistantAgent
 mvn clean install -DskipTests
 ```
 
@@ -236,12 +236,12 @@ public class MyKnowledgeSearchProvider implements SearchProvider {
 │  └─────────────────────────────────────────────────────────┘     │
 │                       │                                          │
 │                       ▼                                          │
-│            ┌────────────────────┐                                │
+│            ┌─────────────────────┐                               │
 │            │ Integrate evaluation│                               │
 │            │ results from        │                               │
 │            │ different dimensions│                               │
 │            │ → Pass to modules   │                               │
-│            └────────────────────┘                                │
+│            └─────────────────────┘                               │
 │                                                                  │
 └──────────────────────────────────────────────────────────────────┘
 ```
@@ -456,7 +456,7 @@ public class MyKnowledgeSearchProvider implements SearchProvider {
 │   │  (self-schedule)│     │                 │     │  Send notify    │   │
 │   └─────────────────┘     └─────────────────┘     └─────────────────┘   │
 │                                                                         │
-│  [Delayed Trigge]                                                       │
+│  [Delayed Trigger]                                                      │
 │                                                                         │
 │   User: "Remind me about the meeting in 30 minutes"                     │
 │            │                                                            │

--- a/README_zh.md
+++ b/README_zh.md
@@ -59,7 +59,7 @@ Assistant Agent 是一个功能完整的智能助手，具备以下核心能力�
 ### 项目结构
 
 ```
-assistant-agent/
+AssistantAgent/
 ├── assistant-agent-common          # 通用工具、枚举、常量
 ├── assistant-agent-core            # 核心引擎：GraalVM 执行器、工具注册表
 ├── assistant-agent-extensions      # 扩展模块：
@@ -87,8 +87,8 @@ assistant-agent/
 ### 1. 克隆并构建
 
 ```bash
-git clone https://github.com/alibaba/assistant-agent.git
-cd assistant-agent
+git clone https://github.com/spring-ai-alibaba/AssistantAgent.git
+cd AssistantAgent
 mvn clean install -DskipTests
 ```
 


### PR DESCRIPTION
## Description

  - Update clone URLs to the new org/repo name and adjust directory names accordingly in README and CONTRIBUTING.

  ## Related Issue

  <!-- Fixes #123 -->

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
  - [x] 📝 Documentation update
  - [ ] 🔧 Refactoring (no functional changes)
  - [ ] 🧪 Test update

  ## Changes Made

  - Point README clone command to `spring-ai-alibaba/AssistantAgent` and use `cd AssistantAgent`.
  - Update CONTRIBUTING quick-setup clone command to the new repo path and directory name.
  - Update CONTRIBUTING fork workflow example to the new repo path and directory name.

  ## How Has This Been Tested?

  - [ ] Unit tests
  - [ ] Integration tests
  - [x] Manual testing

  **Test Configuration:**
  - Java Version:
  - OS:

  ## Checklist

  - [ ] My code follows the project's style guidelines
  - [ ] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing unit tests pass locally with my changes
  - [ ] Any dependent changes have been merged and published

  ## Screenshots (if applicable)

  ## Additional Notes

  - No functional changes; docs only.