### PR TITLE
chore(.github/workflows): 添加构建工作流配置文件

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - develop
+  push:
+    branches:
+      - main
+      - master
+      - develop
+
+jobs:
+  build:
+    name: Build with Maven
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn clean install -B -V
+
+      - name: Run tests
+        run: mvn test -B
+
+      - name: Upload build artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: |
+            **/target/surefire-reports/
+            **/target/*.log
+          retention-days: 7
+


### PR DESCRIPTION
此提交添加了一个新的GitHub Actions工作流配置文件用于自动化构建流程。
#6 的后续Action，主要用于每次PR前的编译检查，确保代码可用

